### PR TITLE
Fix build with XCode 9.3

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,4 @@
-module libxml2 [system] {
+module perfectxml2 [system] {
     header "libxml2.h"
     link "xml2"
     export *


### PR DESCRIPTION
Avoid name conflict with system modulemap

With that change, Perfect-XML compiles fine with XCode 9.3